### PR TITLE
feat: enforce ^[a-z0-9]+$ on product/vendor/suite codes

### DIFF
--- a/.claude/skills/create-product/SKILL.md
+++ b/.claude/skills/create-product/SKILL.md
@@ -82,6 +82,7 @@ package/{vendor}/{suite}/{code}/
 **Required files:** `.npmrc`, `package.json`, `index.yml`, `catalog.yml`, logo file
 
 **Key conventions:**
+- `{vendor}`, `{suite}`, `{code}` must match `^[a-z0-9]+$` — **lowercase alphanumeric only, no hyphens/underscores/dots** (matches ZB platform `vspCodeValidator`)
 - Metadata key: `zerobias` (preferred; `auditmation` still accepted for backwards compatibility)
 - Dataloader version: `"1.0.0"`
 - Scripts use `tsx` (not `ts-node`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,17 @@ Products in this repository can be:
 1. **Vendor Products**: Direct vendor integrations (e.g., `package/github/github/`)
 2. **Suite Products**: Products that belong to a suite (e.g., `package/microsoft/azure/entra/`)
 
+#### Code Format Constraint
+
+`{vendor}`, `{suite}`, and `{code}` must match `^[a-z0-9]+$` — **lowercase alphanumeric only. No hyphens, no underscores, no dots.** This matches the ZB platform UI's `vspCodeValidator`. The API does not enforce this server-side, but the ecosystem (catalog package names, dataloader artifact resolution, schema linkage) requires it. The `validate` script enforces this.
+
 #### Product Directory Structure
 - **Vendor Products**: `package/{vendor}/{code}/`
   - `{vendor}` - Vendor name (e.g., github, okta)
   - `{code}` - Product identifier (e.g., github, okta)
 - **Suite Products**: `package/{vendor}/{suite}/{code}/`
   - `{vendor}` - Vendor name (e.g., microsoft)
-  - `{suite}` - Suite identifier (e.g., azure, 365)  
+  - `{suite}` - Suite identifier (e.g., azure, 365)
   - `{code}` - Product identifier (e.g., entra, teams)
 
 #### Manual Creation Process

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -131,6 +131,10 @@ async function processIndexYml(indexFile: Record<string, any>): Promise<{ code: 
   if (typeof code !== 'string') {
     throw new Error('code in index.yml needs replacement from {code}');
   }
+  // Enforce ^[a-z0-9]+$ — matches ZB platform vspCodeValidator (no hyphens, underscores, or dots)
+  if (!/^[a-z0-9]+$/.test(code)) {
+    throw new Error(`code "${code}" contains invalid characters. Must match ^[a-z0-9]+$ (lowercase alphanumeric only — no hyphens, underscores, or dots).`);
+  }
 
   let check: any;
   check = indexFile.id !== undefined && indexFile.id !== null && indexFile.id !== '{id}' ? new UUID(indexFile.id)
@@ -208,6 +212,15 @@ async function processIndexYml(indexFile: Record<string, any>): Promise<{ code: 
       : new Error('suiteCode not found in index.yml');
   } else {
     throw new Error('parentType in index.yml must be either vendor or suite.');
+  }
+
+  // Enforce ^[a-z0-9]+$ on vendor and suite codes — matches ZB platform vspCodeValidator
+  const codePattern = /^[a-z0-9]+$/;
+  if (typeof vendor === 'string' && !codePattern.test(vendor)) {
+    throw new Error(`vendorCode "${vendor}" contains invalid characters. Must match ^[a-z0-9]+$ (lowercase alphanumeric only).`);
+  }
+  if (suite && typeof suite === 'string' && !codePattern.test(suite)) {
+    throw new Error(`suiteCode "${suite}" contains invalid characters. Must match ^[a-z0-9]+$ (lowercase alphanumeric only).`);
   }
 
   return { code, vendor, suite };


### PR DESCRIPTION
## Summary

Adds `^[a-z0-9]+$` regex validation for `code`, `vendorCode`, and `suiteCode` in `validate.ts`. Matches the ZB platform UI's `vspCodeValidator` constraint: lowercase alphanumeric only, no hyphens, underscores, or dots.

**Why:** The platform UI enforces this on the create product form, but the API doesn't. Without validation in the schema/product repos, codes with hyphens can slip through via GitHub PRs and break the dataloader's artifact resolution (as happened with `sme-mart` vs `smemart`).

### Changes
- `scripts/validate.ts`: Added regex check on code, vendorCode, suiteCode after extraction from index.yml
- `CLAUDE.md`: Added "Code Format Constraint" section documenting `^[a-z0-9]+$` rule
- `.claude/skills/create-product/SKILL.md`: Added constraint to key conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)