### PR TITLE
feat: migrate 10 amazon/aws products to gradle pipeline (batch 1)

### DIFF
--- a/package/amazon/aws/accessanalyzer/build.gradle.kts
+++ b/package/amazon/aws/accessanalyzer/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/accessanalyzer/gate-stamp.json
+++ b/package/amazon/aws/accessanalyzer/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/accounts/build.gradle.kts
+++ b/package/amazon/aws/accounts/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/accounts/gate-stamp.json
+++ b/package/amazon/aws/accounts/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/acm/build.gradle.kts
+++ b/package/amazon/aws/acm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/acm/gate-stamp.json
+++ b/package/amazon/aws/acm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/acmpca/build.gradle.kts
+++ b/package/amazon/aws/acmpca/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/acmpca/gate-stamp.json
+++ b/package/amazon/aws/acmpca/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/alexabusiness/build.gradle.kts
+++ b/package/amazon/aws/alexabusiness/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/alexabusiness/gate-stamp.json
+++ b/package/amazon/aws/alexabusiness/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/amp/build.gradle.kts
+++ b/package/amazon/aws/amp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/amp/gate-stamp.json
+++ b/package/amazon/aws/amp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/amplify/build.gradle.kts
+++ b/package/amazon/aws/amplify/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/amplify/gate-stamp.json
+++ b/package/amazon/aws/amplify/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/amplifyadminui/build.gradle.kts
+++ b/package/amazon/aws/amplifyadminui/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/amplifyadminui/gate-stamp.json
+++ b/package/amazon/aws/amplifyadminui/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/apigateway/build.gradle.kts
+++ b/package/amazon/aws/apigateway/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/apigateway/gate-stamp.json
+++ b/package/amazon/aws/apigateway/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/apigatewaymanagementapi/build.gradle.kts
+++ b/package/amazon/aws/apigatewaymanagementapi/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/apigatewaymanagementapi/gate-stamp.json
+++ b/package/amazon/aws/apigatewaymanagementapi/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}


### PR DESCRIPTION
## Summary

Second per-product batch on the gradle pipeline. First 10 alphabetical `amazon/aws/*` products — suite-parented, all at `2.x` from a prior pass.

`accessanalyzer`, `accounts`, `acm`, `acmpca`, `alexabusiness`, `amp`, `amplify`, `amplifyadminui`, `apigateway`, `apigatewaymanagementapi`

- All grouped under the same parent suite (`amazon/aws`) — `org/suite/package/amazon/aws/build.gradle.kts` confirmed on the gradle line.
- No version bump (skill convention: only `1.x → 2.0.0` gets the major-bump-and-`!`).
- Each commit drops `build.gradle.kts` + `gate-stamp.json`.
- Local `:gate` passed for each. `testIntegrationDataloader` skipped locally (no `NEON_API_KEY`); CI re-runs against ephemeral Neon branch.

Brings repo from 7/663 → 17/663 migrated. Next batches: continue alphabetically through `amazon/aws/*` (~190 left there).

## Test plan

- [ ] CI `detect` job lists exactly these 10 products
- [ ] CI `publish` runs in pre-release mode on the feature branch
- [ ] `testIntegrationDataloader` passes per-product against ephemeral Neon branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)