### PR TITLE
feat: migrate final 25 amazon/aws products to gradle pipeline (batch 4: sqs → xray)

### DIFF
--- a/package/amazon/aws/sqs/build.gradle.kts
+++ b/package/amazon/aws/sqs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/sqs/gate-stamp.json
+++ b/package/amazon/aws/sqs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/sso/build.gradle.kts
+++ b/package/amazon/aws/sso/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/sso/gate-stamp.json
+++ b/package/amazon/aws/sso/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/ssoadmin/build.gradle.kts
+++ b/package/amazon/aws/ssoadmin/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/ssoadmin/gate-stamp.json
+++ b/package/amazon/aws/ssoadmin/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/ssoidentitystore/build.gradle.kts
+++ b/package/amazon/aws/ssoidentitystore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/ssoidentitystore/gate-stamp.json
+++ b/package/amazon/aws/ssoidentitystore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/ssooidc/build.gradle.kts
+++ b/package/amazon/aws/ssooidc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/ssooidc/gate-stamp.json
+++ b/package/amazon/aws/ssooidc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/stepfunctions/build.gradle.kts
+++ b/package/amazon/aws/stepfunctions/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/stepfunctions/gate-stamp.json
+++ b/package/amazon/aws/stepfunctions/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/storagegatewayservice/build.gradle.kts
+++ b/package/amazon/aws/storagegatewayservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/storagegatewayservice/gate-stamp.json
+++ b/package/amazon/aws/storagegatewayservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/sts/build.gradle.kts
+++ b/package/amazon/aws/sts/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/sts/gate-stamp.json
+++ b/package/amazon/aws/sts/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/support/build.gradle.kts
+++ b/package/amazon/aws/support/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/support/gate-stamp.json
+++ b/package/amazon/aws/support/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/swf/build.gradle.kts
+++ b/package/amazon/aws/swf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/swf/gate-stamp.json
+++ b/package/amazon/aws/swf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/system/build.gradle.kts
+++ b/package/amazon/aws/system/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/system/gate-stamp.json
+++ b/package/amazon/aws/system/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/systemsmanager/build.gradle.kts
+++ b/package/amazon/aws/systemsmanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/systemsmanager/gate-stamp.json
+++ b/package/amazon/aws/systemsmanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/textract/build.gradle.kts
+++ b/package/amazon/aws/textract/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/textract/gate-stamp.json
+++ b/package/amazon/aws/textract/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/timestream/build.gradle.kts
+++ b/package/amazon/aws/timestream/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/timestream/gate-stamp.json
+++ b/package/amazon/aws/timestream/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/transcribe/build.gradle.kts
+++ b/package/amazon/aws/transcribe/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/transcribe/gate-stamp.json
+++ b/package/amazon/aws/transcribe/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/transferfamily/build.gradle.kts
+++ b/package/amazon/aws/transferfamily/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/transferfamily/gate-stamp.json
+++ b/package/amazon/aws/transferfamily/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/translate/build.gradle.kts
+++ b/package/amazon/aws/translate/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/translate/gate-stamp.json
+++ b/package/amazon/aws/translate/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/vpc/build.gradle.kts
+++ b/package/amazon/aws/vpc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/vpc/gate-stamp.json
+++ b/package/amazon/aws/vpc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/waf/build.gradle.kts
+++ b/package/amazon/aws/waf/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/waf/gate-stamp.json
+++ b/package/amazon/aws/waf/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/wellarchitectedtool/build.gradle.kts
+++ b/package/amazon/aws/wellarchitectedtool/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/wellarchitectedtool/gate-stamp.json
+++ b/package/amazon/aws/wellarchitectedtool/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/workdocs/build.gradle.kts
+++ b/package/amazon/aws/workdocs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/workdocs/gate-stamp.json
+++ b/package/amazon/aws/workdocs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/worklink/build.gradle.kts
+++ b/package/amazon/aws/worklink/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/worklink/gate-stamp.json
+++ b/package/amazon/aws/worklink/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/workmail/build.gradle.kts
+++ b/package/amazon/aws/workmail/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/workmail/gate-stamp.json
+++ b/package/amazon/aws/workmail/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/workspacesservice/build.gradle.kts
+++ b/package/amazon/aws/workspacesservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/workspacesservice/gate-stamp.json
+++ b/package/amazon/aws/workspacesservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/amazon/aws/xray/build.gradle.kts
+++ b/package/amazon/aws/xray/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/amazon/aws/xray/gate-stamp.json
+++ b/package/amazon/aws/xray/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-amazon-aws-batch-4",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}


### PR DESCRIPTION
## Summary

Final batch for `amazon/aws/*` — 25 remaining products. Alphabetical range: **sqs → xray**. After merge, **all 235 amazon/aws products** are on the gradle pipeline.

- 25 commits, one per product.
- All at `2.x` from a prior pass — no version bump.
- Pre-flight: zero anomalies.
- Local `:gate` ran in single parallelized invocation (~16s). All passed.

Smaller than the 100 cap because this completes the vendor. Next batches will pivot to `microsoft/azure` (~145 products) at the requested 100/PR cadence.

Brings repo from 217/660 → 242/660 migrated (~37%).

## Test plan

- [ ] CI `detect` lists exactly these 25 products
- [ ] CI `publish` runs in pre-release mode on the feature branch
- [ ] `testIntegrationDataloader` passes per-product

🤖 Generated with [Claude Code](https://claude.com/claude-code)