### PR TITLE
feat: migrate final 53 microsoft/azure products to gradle pipeline (batch 2: msgraph → windowsvirtualdesktop)

### DIFF
--- a/package/microsoft/azure/msgraph/build.gradle.kts
+++ b/package/microsoft/azure/msgraph/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/msgraph/gate-stamp.json
+++ b/package/microsoft/azure/msgraph/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/mysql/build.gradle.kts
+++ b/package/microsoft/azure/mysql/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/mysql/gate-stamp.json
+++ b/package/microsoft/azure/mysql/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/networkgateway/build.gradle.kts
+++ b/package/microsoft/azure/networkgateway/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/networkgateway/gate-stamp.json
+++ b/package/microsoft/azure/networkgateway/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/networkwatcher/build.gradle.kts
+++ b/package/microsoft/azure/networkwatcher/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/networkwatcher/gate-stamp.json
+++ b/package/microsoft/azure/networkwatcher/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/notificationhubs/build.gradle.kts
+++ b/package/microsoft/azure/notificationhubs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/notificationhubs/gate-stamp.json
+++ b/package/microsoft/azure/notificationhubs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/peering/build.gradle.kts
+++ b/package/microsoft/azure/peering/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/peering/gate-stamp.json
+++ b/package/microsoft/azure/peering/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/policy/build.gradle.kts
+++ b/package/microsoft/azure/policy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/policy/gate-stamp.json
+++ b/package/microsoft/azure/policy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/postgresql/build.gradle.kts
+++ b/package/microsoft/azure/postgresql/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/postgresql/gate-stamp.json
+++ b/package/microsoft/azure/postgresql/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/powerbiembedded/build.gradle.kts
+++ b/package/microsoft/azure/powerbiembedded/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/powerbiembedded/gate-stamp.json
+++ b/package/microsoft/azure/powerbiembedded/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/powerbiworkspacecollections/build.gradle.kts
+++ b/package/microsoft/azure/powerbiworkspacecollections/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/powerbiworkspacecollections/gate-stamp.json
+++ b/package/microsoft/azure/powerbiworkspacecollections/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/purview/build.gradle.kts
+++ b/package/microsoft/azure/purview/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/purview/gate-stamp.json
+++ b/package/microsoft/azure/purview/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/queueservice/build.gradle.kts
+++ b/package/microsoft/azure/queueservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/queueservice/gate-stamp.json
+++ b/package/microsoft/azure/queueservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/recoveryservices/build.gradle.kts
+++ b/package/microsoft/azure/recoveryservices/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/recoveryservices/gate-stamp.json
+++ b/package/microsoft/azure/recoveryservices/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/recoveryservicesbackup/build.gradle.kts
+++ b/package/microsoft/azure/recoveryservicesbackup/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/recoveryservicesbackup/gate-stamp.json
+++ b/package/microsoft/azure/recoveryservicesbackup/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/recoveryservicessiterecovery/build.gradle.kts
+++ b/package/microsoft/azure/recoveryservicessiterecovery/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/recoveryservicessiterecovery/gate-stamp.json
+++ b/package/microsoft/azure/recoveryservicessiterecovery/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/redhatopenshift/build.gradle.kts
+++ b/package/microsoft/azure/redhatopenshift/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/redhatopenshift/gate-stamp.json
+++ b/package/microsoft/azure/redhatopenshift/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/rediscache/build.gradle.kts
+++ b/package/microsoft/azure/rediscache/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/rediscache/gate-stamp.json
+++ b/package/microsoft/azure/rediscache/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/relay/build.gradle.kts
+++ b/package/microsoft/azure/relay/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/relay/gate-stamp.json
+++ b/package/microsoft/azure/relay/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/reservedvminstances/build.gradle.kts
+++ b/package/microsoft/azure/reservedvminstances/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/reservedvminstances/gate-stamp.json
+++ b/package/microsoft/azure/reservedvminstances/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/resourcehealth/build.gradle.kts
+++ b/package/microsoft/azure/resourcehealth/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/resourcehealth/gate-stamp.json
+++ b/package/microsoft/azure/resourcehealth/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/resourcemanagement/build.gradle.kts
+++ b/package/microsoft/azure/resourcemanagement/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/resourcemanagement/gate-stamp.json
+++ b/package/microsoft/azure/resourcemanagement/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/resourcemanager/build.gradle.kts
+++ b/package/microsoft/azure/resourcemanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/resourcemanager/gate-stamp.json
+++ b/package/microsoft/azure/resourcemanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/resourcemover/build.gradle.kts
+++ b/package/microsoft/azure/resourcemover/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/resourcemover/gate-stamp.json
+++ b/package/microsoft/azure/resourcemover/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/scheduler/build.gradle.kts
+++ b/package/microsoft/azure/scheduler/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/scheduler/gate-stamp.json
+++ b/package/microsoft/azure/scheduler/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/searchmanagement/build.gradle.kts
+++ b/package/microsoft/azure/searchmanagement/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/searchmanagement/gate-stamp.json
+++ b/package/microsoft/azure/searchmanagement/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/searchservice/build.gradle.kts
+++ b/package/microsoft/azure/searchservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/searchservice/gate-stamp.json
+++ b/package/microsoft/azure/searchservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/securitycenter/build.gradle.kts
+++ b/package/microsoft/azure/securitycenter/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/securitycenter/gate-stamp.json
+++ b/package/microsoft/azure/securitycenter/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/sentinel/build.gradle.kts
+++ b/package/microsoft/azure/sentinel/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/sentinel/gate-stamp.json
+++ b/package/microsoft/azure/sentinel/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/serialconsole/build.gradle.kts
+++ b/package/microsoft/azure/serialconsole/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/serialconsole/gate-stamp.json
+++ b/package/microsoft/azure/serialconsole/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/servicebus/build.gradle.kts
+++ b/package/microsoft/azure/servicebus/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/servicebus/gate-stamp.json
+++ b/package/microsoft/azure/servicebus/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/servicefabric/build.gradle.kts
+++ b/package/microsoft/azure/servicefabric/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/servicefabric/gate-stamp.json
+++ b/package/microsoft/azure/servicefabric/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/servicemap/build.gradle.kts
+++ b/package/microsoft/azure/servicemap/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/servicemap/gate-stamp.json
+++ b/package/microsoft/azure/servicemap/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/signalrservice/build.gradle.kts
+++ b/package/microsoft/azure/signalrservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/signalrservice/gate-stamp.json
+++ b/package/microsoft/azure/signalrservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/speakerrecognition/build.gradle.kts
+++ b/package/microsoft/azure/speakerrecognition/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/speakerrecognition/gate-stamp.json
+++ b/package/microsoft/azure/speakerrecognition/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/sql/build.gradle.kts
+++ b/package/microsoft/azure/sql/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/sql/gate-stamp.json
+++ b/package/microsoft/azure/sql/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/sqldatabase/build.gradle.kts
+++ b/package/microsoft/azure/sqldatabase/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/sqldatabase/gate-stamp.json
+++ b/package/microsoft/azure/sqldatabase/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/sqlvm/build.gradle.kts
+++ b/package/microsoft/azure/sqlvm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/sqlvm/gate-stamp.json
+++ b/package/microsoft/azure/sqlvm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/storagecache/build.gradle.kts
+++ b/package/microsoft/azure/storagecache/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/storagecache/gate-stamp.json
+++ b/package/microsoft/azure/storagecache/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/storageimportexport/build.gradle.kts
+++ b/package/microsoft/azure/storageimportexport/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/storageimportexport/gate-stamp.json
+++ b/package/microsoft/azure/storageimportexport/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/storageresourceprovider/build.gradle.kts
+++ b/package/microsoft/azure/storageresourceprovider/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/storageresourceprovider/gate-stamp.json
+++ b/package/microsoft/azure/storageresourceprovider/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/storageservices/build.gradle.kts
+++ b/package/microsoft/azure/storageservices/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/storageservices/gate-stamp.json
+++ b/package/microsoft/azure/storageservices/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/storsimple/build.gradle.kts
+++ b/package/microsoft/azure/storsimple/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/storsimple/gate-stamp.json
+++ b/package/microsoft/azure/storsimple/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/streamanalytics/build.gradle.kts
+++ b/package/microsoft/azure/streamanalytics/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/streamanalytics/gate-stamp.json
+++ b/package/microsoft/azure/streamanalytics/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/subscription/build.gradle.kts
+++ b/package/microsoft/azure/subscription/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/subscription/gate-stamp.json
+++ b/package/microsoft/azure/subscription/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/support/build.gradle.kts
+++ b/package/microsoft/azure/support/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/support/gate-stamp.json
+++ b/package/microsoft/azure/support/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/synapse/build.gradle.kts
+++ b/package/microsoft/azure/synapse/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/synapse/gate-stamp.json
+++ b/package/microsoft/azure/synapse/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/tableservice/build.gradle.kts
+++ b/package/microsoft/azure/tableservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/tableservice/gate-stamp.json
+++ b/package/microsoft/azure/tableservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/timeseriesinsights/build.gradle.kts
+++ b/package/microsoft/azure/timeseriesinsights/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/timeseriesinsights/gate-stamp.json
+++ b/package/microsoft/azure/timeseriesinsights/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/trafficmanager/build.gradle.kts
+++ b/package/microsoft/azure/trafficmanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/trafficmanager/gate-stamp.json
+++ b/package/microsoft/azure/trafficmanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/virtualnetworks/build.gradle.kts
+++ b/package/microsoft/azure/virtualnetworks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/virtualnetworks/gate-stamp.json
+++ b/package/microsoft/azure/virtualnetworks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/virtualwan/build.gradle.kts
+++ b/package/microsoft/azure/virtualwan/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/virtualwan/gate-stamp.json
+++ b/package/microsoft/azure/virtualwan/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/visualstudio/build.gradle.kts
+++ b/package/microsoft/azure/visualstudio/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/visualstudio/gate-stamp.json
+++ b/package/microsoft/azure/visualstudio/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/microsoft/azure/windowsvirtualdesktop/build.gradle.kts
+++ b/package/microsoft/azure/windowsvirtualdesktop/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/microsoft/azure/windowsvirtualdesktop/gate-stamp.json
+++ b/package/microsoft/azure/windowsvirtualdesktop/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-microsoft-azure-batch-2",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}


### PR DESCRIPTION
## Summary

Final batch for `microsoft/azure/*` — 53 remaining products. Alphabetical range: **msgraph → windowsvirtualdesktop**. After merge, **all 153 microsoft/azure products** are on the gradle pipeline.

- 53 commits, one per product.
- All at `2.0.1` from a prior pass — no version bump.
- Pre-flight: zero anomalies (validator floor change from PR #20 is already on main).
- Local `:gate` ran in single parallelized invocation (~20s). All passed.

Smaller than 100 because this completes the vendor. Next batches will pick the next suite-parented vendor (likely `google/cloud` or `google/gcp` — pending inventory check).

Brings repo from 342/660 → 395/660 migrated (~60%).

## Test plan

- [ ] CI `detect` lists exactly these 53 products
- [ ] CI `publish` runs in pre-release mode on the feature branch
- [ ] `testIntegrationDataloader` passes per-product

🤖 Generated with [Claude Code](https://claude.com/claude-code)