### PR TITLE
feat: migrate 95 google products to gradle pipeline (gcp + workspace; skips 4 logo issues)

### DIFF
--- a/package/google/gcp/accessapproval/build.gradle.kts
+++ b/package/google/gcp/accessapproval/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/accessapproval/gate-stamp.json
+++ b/package/google/gcp/accessapproval/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/accesscontextmanager/build.gradle.kts
+++ b/package/google/gcp/accesscontextmanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/accesscontextmanager/gate-stamp.json
+++ b/package/google/gcp/accesscontextmanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/apigateway/build.gradle.kts
+++ b/package/google/gcp/apigateway/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/apigateway/gate-stamp.json
+++ b/package/google/gcp/apigateway/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/apigee/build.gradle.kts
+++ b/package/google/gcp/apigee/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/apigee/gate-stamp.json
+++ b/package/google/gcp/apigee/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/apikeys/build.gradle.kts
+++ b/package/google/gcp/apikeys/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/apikeys/gate-stamp.json
+++ b/package/google/gcp/apikeys/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/appengine/build.gradle.kts
+++ b/package/google/gcp/appengine/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/appengine/gate-stamp.json
+++ b/package/google/gcp/appengine/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/artifactregistry/build.gradle.kts
+++ b/package/google/gcp/artifactregistry/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/artifactregistry/gate-stamp.json
+++ b/package/google/gcp/artifactregistry/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/assetinventory/build.gradle.kts
+++ b/package/google/gcp/assetinventory/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/assetinventory/gate-stamp.json
+++ b/package/google/gcp/assetinventory/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/assuredworkloads/build.gradle.kts
+++ b/package/google/gcp/assuredworkloads/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/assuredworkloads/gate-stamp.json
+++ b/package/google/gcp/assuredworkloads/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/bigquery/build.gradle.kts
+++ b/package/google/gcp/bigquery/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/bigquery/gate-stamp.json
+++ b/package/google/gcp/bigquery/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/bigquerytransfer/build.gradle.kts
+++ b/package/google/gcp/bigquerytransfer/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/bigquerytransfer/gate-stamp.json
+++ b/package/google/gcp/bigquerytransfer/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/bigtable/build.gradle.kts
+++ b/package/google/gcp/bigtable/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/bigtable/gate-stamp.json
+++ b/package/google/gcp/bigtable/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/billing/build.gradle.kts
+++ b/package/google/gcp/billing/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/billing/gate-stamp.json
+++ b/package/google/gcp/billing/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/binaryauthorization/build.gradle.kts
+++ b/package/google/gcp/binaryauthorization/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/binaryauthorization/gate-stamp.json
+++ b/package/google/gcp/binaryauthorization/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/certificateauthorityservice/build.gradle.kts
+++ b/package/google/gcp/certificateauthorityservice/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/certificateauthorityservice/gate-stamp.json
+++ b/package/google/gcp/certificateauthorityservice/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/channel/build.gradle.kts
+++ b/package/google/gcp/channel/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/channel/gate-stamp.json
+++ b/package/google/gcp/channel/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/cloudprofiler/build.gradle.kts
+++ b/package/google/gcp/cloudprofiler/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/cloudprofiler/gate-stamp.json
+++ b/package/google/gcp/cloudprofiler/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/composer/build.gradle.kts
+++ b/package/google/gcp/composer/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/composer/gate-stamp.json
+++ b/package/google/gcp/composer/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/computeengine/build.gradle.kts
+++ b/package/google/gcp/computeengine/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/computeengine/gate-stamp.json
+++ b/package/google/gcp/computeengine/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/containeranalysis/build.gradle.kts
+++ b/package/google/gcp/containeranalysis/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/containeranalysis/gate-stamp.json
+++ b/package/google/gcp/containeranalysis/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/containerregistry/build.gradle.kts
+++ b/package/google/gcp/containerregistry/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/containerregistry/gate-stamp.json
+++ b/package/google/gcp/containerregistry/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/databasemigration/build.gradle.kts
+++ b/package/google/gcp/databasemigration/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/databasemigration/gate-stamp.json
+++ b/package/google/gcp/databasemigration/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/datacatalog/build.gradle.kts
+++ b/package/google/gcp/datacatalog/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/datacatalog/gate-stamp.json
+++ b/package/google/gcp/datacatalog/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/dataflow/build.gradle.kts
+++ b/package/google/gcp/dataflow/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/dataflow/gate-stamp.json
+++ b/package/google/gcp/dataflow/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/datafusion/build.gradle.kts
+++ b/package/google/gcp/datafusion/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/datafusion/gate-stamp.json
+++ b/package/google/gcp/datafusion/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/datalabeling/build.gradle.kts
+++ b/package/google/gcp/datalabeling/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/datalabeling/gate-stamp.json
+++ b/package/google/gcp/datalabeling/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/dataproc/build.gradle.kts
+++ b/package/google/gcp/dataproc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/dataproc/gate-stamp.json
+++ b/package/google/gcp/dataproc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/dataprocmetastore/build.gradle.kts
+++ b/package/google/gcp/dataprocmetastore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/dataprocmetastore/gate-stamp.json
+++ b/package/google/gcp/dataprocmetastore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/datastore/build.gradle.kts
+++ b/package/google/gcp/datastore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/datastore/gate-stamp.json
+++ b/package/google/gcp/datastore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/debugger/build.gradle.kts
+++ b/package/google/gcp/debugger/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/debugger/gate-stamp.json
+++ b/package/google/gcp/debugger/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/deploymentmanager/build.gradle.kts
+++ b/package/google/gcp/deploymentmanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/deploymentmanager/gate-stamp.json
+++ b/package/google/gcp/deploymentmanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/dialogflow/build.gradle.kts
+++ b/package/google/gcp/dialogflow/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/dialogflow/gate-stamp.json
+++ b/package/google/gcp/dialogflow/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/dlp/build.gradle.kts
+++ b/package/google/gcp/dlp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/dlp/gate-stamp.json
+++ b/package/google/gcp/dlp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/dns/build.gradle.kts
+++ b/package/google/gcp/dns/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/dns/gate-stamp.json
+++ b/package/google/gcp/dns/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/documentai/build.gradle.kts
+++ b/package/google/gcp/documentai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/documentai/gate-stamp.json
+++ b/package/google/gcp/documentai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/domains/build.gradle.kts
+++ b/package/google/gcp/domains/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/domains/gate-stamp.json
+++ b/package/google/gcp/domains/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/errorreporting/build.gradle.kts
+++ b/package/google/gcp/errorreporting/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/errorreporting/gate-stamp.json
+++ b/package/google/gcp/errorreporting/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/eventarc/build.gradle.kts
+++ b/package/google/gcp/eventarc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/eventarc/gate-stamp.json
+++ b/package/google/gcp/eventarc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/filestore/build.gradle.kts
+++ b/package/google/gcp/filestore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/filestore/gate-stamp.json
+++ b/package/google/gcp/filestore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/firestore/build.gradle.kts
+++ b/package/google/gcp/firestore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/firestore/gate-stamp.json
+++ b/package/google/gcp/firestore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/functions/build.gradle.kts
+++ b/package/google/gcp/functions/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/functions/gate-stamp.json
+++ b/package/google/gcp/functions/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/gameservers/build.gradle.kts
+++ b/package/google/gcp/gameservers/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/gameservers/gate-stamp.json
+++ b/package/google/gcp/gameservers/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/gkehub/build.gradle.kts
+++ b/package/google/gcp/gkehub/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/gkehub/gate-stamp.json
+++ b/package/google/gcp/gkehub/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/healthcare/build.gradle.kts
+++ b/package/google/gcp/healthcare/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/healthcare/gate-stamp.json
+++ b/package/google/gcp/healthcare/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/iam/build.gradle.kts
+++ b/package/google/gcp/iam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/iam/gate-stamp.json
+++ b/package/google/gcp/iam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/iap/build.gradle.kts
+++ b/package/google/gcp/iap/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/iap/gate-stamp.json
+++ b/package/google/gcp/iap/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/identity/build.gradle.kts
+++ b/package/google/gcp/identity/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/identity/gate-stamp.json
+++ b/package/google/gcp/identity/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/kms/build.gradle.kts
+++ b/package/google/gcp/kms/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/kms/gate-stamp.json
+++ b/package/google/gcp/kms/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/kubernetesengine/build.gradle.kts
+++ b/package/google/gcp/kubernetesengine/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/kubernetesengine/gate-stamp.json
+++ b/package/google/gcp/kubernetesengine/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/libraryagent/build.gradle.kts
+++ b/package/google/gcp/libraryagent/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/libraryagent/gate-stamp.json
+++ b/package/google/gcp/libraryagent/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/lifesciences/build.gradle.kts
+++ b/package/google/gcp/lifesciences/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/lifesciences/gate-stamp.json
+++ b/package/google/gcp/lifesciences/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/logging/build.gradle.kts
+++ b/package/google/gcp/logging/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/logging/gate-stamp.json
+++ b/package/google/gcp/logging/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/managedmicrosoftad/build.gradle.kts
+++ b/package/google/gcp/managedmicrosoftad/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/managedmicrosoftad/gate-stamp.json
+++ b/package/google/gcp/managedmicrosoftad/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/memorystore/build.gradle.kts
+++ b/package/google/gcp/memorystore/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/memorystore/gate-stamp.json
+++ b/package/google/gcp/memorystore/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/monitoring/build.gradle.kts
+++ b/package/google/gcp/monitoring/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/monitoring/gate-stamp.json
+++ b/package/google/gcp/monitoring/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/naturallanguage/build.gradle.kts
+++ b/package/google/gcp/naturallanguage/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/naturallanguage/gate-stamp.json
+++ b/package/google/gcp/naturallanguage/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/networkconnectivity/build.gradle.kts
+++ b/package/google/gcp/networkconnectivity/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/networkconnectivity/gate-stamp.json
+++ b/package/google/gcp/networkconnectivity/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/networkintelligencecenter/build.gradle.kts
+++ b/package/google/gcp/networkintelligencecenter/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/networkintelligencecenter/gate-stamp.json
+++ b/package/google/gcp/networkintelligencecenter/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/notebooks/build.gradle.kts
+++ b/package/google/gcp/notebooks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/notebooks/gate-stamp.json
+++ b/package/google/gcp/notebooks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/ondemandscanning/build.gradle.kts
+++ b/package/google/gcp/ondemandscanning/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/ondemandscanning/gate-stamp.json
+++ b/package/google/gcp/ondemandscanning/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/prediction/build.gradle.kts
+++ b/package/google/gcp/prediction/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/prediction/gate-stamp.json
+++ b/package/google/gcp/prediction/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/pubsub/build.gradle.kts
+++ b/package/google/gcp/pubsub/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/pubsub/gate-stamp.json
+++ b/package/google/gcp/pubsub/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/recommendationsai/build.gradle.kts
+++ b/package/google/gcp/recommendationsai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/recommendationsai/gate-stamp.json
+++ b/package/google/gcp/recommendationsai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/recommender/build.gradle.kts
+++ b/package/google/gcp/recommender/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/recommender/gate-stamp.json
+++ b/package/google/gcp/recommender/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/remotebuildexecution/build.gradle.kts
+++ b/package/google/gcp/remotebuildexecution/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/remotebuildexecution/gate-stamp.json
+++ b/package/google/gcp/remotebuildexecution/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/resourcemanager/build.gradle.kts
+++ b/package/google/gcp/resourcemanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/resourcemanager/gate-stamp.json
+++ b/package/google/gcp/resourcemanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/retail/build.gradle.kts
+++ b/package/google/gcp/retail/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/retail/gate-stamp.json
+++ b/package/google/gcp/retail/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/run/build.gradle.kts
+++ b/package/google/gcp/run/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/run/gate-stamp.json
+++ b/package/google/gcp/run/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/scheduler/build.gradle.kts
+++ b/package/google/gcp/scheduler/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/scheduler/gate-stamp.json
+++ b/package/google/gcp/scheduler/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/secretmanager/build.gradle.kts
+++ b/package/google/gcp/secretmanager/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/secretmanager/gate-stamp.json
+++ b/package/google/gcp/secretmanager/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/securitycommandcenter/build.gradle.kts
+++ b/package/google/gcp/securitycommandcenter/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/securitycommandcenter/gate-stamp.json
+++ b/package/google/gcp/securitycommandcenter/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/servicedirectory/build.gradle.kts
+++ b/package/google/gcp/servicedirectory/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/servicedirectory/gate-stamp.json
+++ b/package/google/gcp/servicedirectory/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/serviceinfrastructure/build.gradle.kts
+++ b/package/google/gcp/serviceinfrastructure/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/serviceinfrastructure/gate-stamp.json
+++ b/package/google/gcp/serviceinfrastructure/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/servicemetadata/build.gradle.kts
+++ b/package/google/gcp/servicemetadata/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/servicemetadata/gate-stamp.json
+++ b/package/google/gcp/servicemetadata/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/serviceusage/build.gradle.kts
+++ b/package/google/gcp/serviceusage/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/serviceusage/gate-stamp.json
+++ b/package/google/gcp/serviceusage/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/shell/build.gradle.kts
+++ b/package/google/gcp/shell/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/shell/gate-stamp.json
+++ b/package/google/gcp/shell/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/sourcerepositories/build.gradle.kts
+++ b/package/google/gcp/sourcerepositories/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/sourcerepositories/gate-stamp.json
+++ b/package/google/gcp/sourcerepositories/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/spanner/build.gradle.kts
+++ b/package/google/gcp/spanner/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/spanner/gate-stamp.json
+++ b/package/google/gcp/spanner/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/speechtotext/build.gradle.kts
+++ b/package/google/gcp/speechtotext/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/speechtotext/gate-stamp.json
+++ b/package/google/gcp/speechtotext/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/sql/build.gradle.kts
+++ b/package/google/gcp/sql/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/sql/gate-stamp.json
+++ b/package/google/gcp/sql/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/storage/build.gradle.kts
+++ b/package/google/gcp/storage/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/storage/gate-stamp.json
+++ b/package/google/gcp/storage/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/storagetransfer/build.gradle.kts
+++ b/package/google/gcp/storagetransfer/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/storagetransfer/gate-stamp.json
+++ b/package/google/gcp/storagetransfer/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/talentsolution/build.gradle.kts
+++ b/package/google/gcp/talentsolution/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/talentsolution/gate-stamp.json
+++ b/package/google/gcp/talentsolution/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/tasks/build.gradle.kts
+++ b/package/google/gcp/tasks/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/tasks/gate-stamp.json
+++ b/package/google/gcp/tasks/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/texttospeech/build.gradle.kts
+++ b/package/google/gcp/texttospeech/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/texttospeech/gate-stamp.json
+++ b/package/google/gcp/texttospeech/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/trafficdirector/build.gradle.kts
+++ b/package/google/gcp/trafficdirector/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/trafficdirector/gate-stamp.json
+++ b/package/google/gcp/trafficdirector/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/transcoder/build.gradle.kts
+++ b/package/google/gcp/transcoder/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/transcoder/gate-stamp.json
+++ b/package/google/gcp/transcoder/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/translate/build.gradle.kts
+++ b/package/google/gcp/translate/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/translate/gate-stamp.json
+++ b/package/google/gcp/translate/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/videointelligence/build.gradle.kts
+++ b/package/google/gcp/videointelligence/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/videointelligence/gate-stamp.json
+++ b/package/google/gcp/videointelligence/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/webrisk/build.gradle.kts
+++ b/package/google/gcp/webrisk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/webrisk/gate-stamp.json
+++ b/package/google/gcp/webrisk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/workflowexecutions/build.gradle.kts
+++ b/package/google/gcp/workflowexecutions/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/workflowexecutions/gate-stamp.json
+++ b/package/google/gcp/workflowexecutions/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/gcp/workflows/build.gradle.kts
+++ b/package/google/gcp/workflows/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/gcp/workflows/gate-stamp.json
+++ b/package/google/gcp/workflows/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/workspace/admin/build.gradle.kts
+++ b/package/google/workspace/admin/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/workspace/admin/gate-stamp.json
+++ b/package/google/workspace/admin/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/workspace/drive/build.gradle.kts
+++ b/package/google/workspace/drive/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/workspace/drive/gate-stamp.json
+++ b/package/google/workspace/drive/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/google/workspace/sheets/build.gradle.kts
+++ b/package/google/workspace/sheets/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/google/workspace/sheets/gate-stamp.json
+++ b/package/google/workspace/sheets/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.0.1-uat.0",
+  "branch": "chore/migrate-google-batch-1",
+  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}


### PR DESCRIPTION
## Summary

Single-vendor batch: all `google/*` products migrated except 4 with logo-extension mismatches that need separate handling.

**Included:** 92 `google/gcp/*` + 3 `google/workspace/*` = **95 products**.

**Excluded — needs follow-up:** 4 `google/gcp/*` products ship PNG-content files named `logo.svg`:
- `iot` (10167B)
- `tpu` (8418B)
- `vision` (7983B)
- `trace` (2382B)

The validator correctly rejects these (PNG magic bytes in a .svg-named file). Fix is out-of-scope here because:
- Local rename `logo.svg` → `logo.png` is mechanical
- `index.yml.logo` URL also references `.svg` and may correspond to a CDN-hosted asset — the rename needs to be coordinated with CDN ops, or the URL needs `.png` too
- Either way it's not a gradle-pipeline concern

These 4 will be addressed in a follow-up PR once the logo-URL strategy is decided.

### Migrations
- 95 commits, one per product.
- All at `2.0.1` from a prior pass — no version bump.
- Local `:gate` ran in single parallelized invocation (~13s). All passed.

### Progress
- microsoft is also done (other than the small leftovers in 365/windows/defender).
- google: 95/99 done with this PR; 4 left for logo cleanup.
- Brings repo from 395/660 → 490/660 migrated (~74%).

## Test plan

- [ ] CI `detect` lists exactly these 95 products
- [ ] CI `publish` runs in pre-release mode on the feature branch
- [ ] `testIntegrationDataloader` passes per-product

🤖 Generated with [Claude Code](https://claude.com/claude-code)