### PR TITLE
chore(bundle)!: bump to 1.0.0

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/product-bundle",
-  "version": "0.0.26",
+  "version": "1.0.0",
   "description": "All installable products",
   "author": "team@auditmation.io",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Marks the first stable bundle release after the gradle pipeline migration. All 660 products now publish via gradle/zbb (PRs #14–#25). This commit bumps the bundle's own version `0.0.25 → 1.0.0`.

Deps refresh continues to be handled by the existing CI `update-bundle` job — this PR doesn't touch the dependency list.

The `!` marks the major bump as breaking.

## Test plan

- [ ] CI `detect` lists only `bundle/`
- [ ] CI publishes `@zerobias-org/product-bundle@1.0.0` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)