### PR TITLE
fix(product-github-github): improve catalog accuracy

### DIFF
--- a/package/github/github/components/actions.yml
+++ b/package/github/github/components/actions.yml
@@ -1,0 +1,6 @@
+id: 6fbe8449-a401-4a66-ad18-801e6fe82e62
+name: GitHub Actions
+description: >-
+  Automate your build, test, and deployment workflows with CI/CD pipelines that run directly in your repository, triggered by GitHub events.
+background: >-
+  GitHub Actions makes it easy to automate all your software workflows — build, test, and deploy your code right from GitHub. Workflows run on GitHub-hosted or self-hosted runners and can be triggered by repository events such as push, pull request, release, and schedule. Reusable, community-built actions are available from the GitHub Marketplace. Usage is free for public repositories and self-hosted runners; private repositories include a monthly allotment of minutes and storage that varies by plan.

--- a/package/github/github/components/advanced-security.yml
+++ b/package/github/github/components/advanced-security.yml
@@ -1,0 +1,6 @@
+id: cadb2ec8-802c-4489-a988-0d9833cda05d
+name: GitHub Advanced Security
+description: >-
+  A suite of application-security tools — code scanning, secret scanning, and dependency review — to find and fix vulnerabilities in code and dependencies.
+background: >-
+  GitHub Advanced Security (offered as GitHub Code Security and GitHub Secret Protection) adds security capabilities including CodeQL code scanning (static analysis), secret scanning with push protection, security overview dashboards, and dependency review. It is included for public repositories and available as a paid add-on for private and enterprise repositories.

--- a/package/github/github/components/advisory-database.yml
+++ b/package/github/github/components/advisory-database.yml
@@ -1,0 +1,6 @@
+id: a49eff92-d0d8-49a2-bd91-932be11b7620
+name: GitHub Advisory Database
+description: >-
+  A curated database of security vulnerabilities and malware affecting open-source software, powering Dependabot alerts.
+background: >-
+  The GitHub Advisory Database is a free, curated set of security advisories — CVEs and GitHub-reviewed advisories — for packages across major ecosystems. It powers Dependabot alerts and dependency review, and accepts community contributions to improve advisory quality and coverage.

--- a/package/github/github/components/codespaces.yml
+++ b/package/github/github/components/codespaces.yml
@@ -1,0 +1,6 @@
+id: deb10550-35ac-4e6e-8f86-5b51c8c8f1d6
+name: GitHub Codespaces
+description: >-
+  A cloud-hosted, configurable development environment that lets you code from the browser or your editor without local setup.
+background: >-
+  GitHub Codespaces provides instant, cloud-based development environments backed by Visual Studio Code in the browser or your local IDE. Each codespace runs on a configurable virtual machine and can be customized with dev containers, letting developers spin up a fully configured environment from any repository in seconds. Usage is billed by compute core-hours and storage, with monthly allowances included by plan.

--- a/package/github/github/components/copilot.yml
+++ b/package/github/github/components/copilot.yml
@@ -1,0 +1,6 @@
+id: aaa9ecc1-78fe-4823-9a05-02c88be391be
+name: GitHub Copilot
+description: >-
+  An AI pair programmer that suggests whole lines and functions, answers coding questions in chat, and helps review and refactor code.
+background: >-
+  GitHub Copilot is an AI-powered coding assistant that provides autocomplete-style code suggestions, a chat interface for explaining and generating code, and integrations across the editor, CLI, and GitHub.com. It supports many programming languages and offers individual, business, and enterprise plans with policy, privacy, and security controls.

--- a/package/github/github/components/discussions.yml
+++ b/package/github/github/components/discussions.yml
@@ -1,0 +1,6 @@
+id: 22fd2c14-84b9-406f-aac1-30e57154028d
+name: GitHub Discussions
+description: >-
+  A collaborative communication forum for a repository or organization community to ask questions and share ideas.
+background: >-
+  GitHub Discussions provides a dedicated space, separate from issues, for open-ended conversation — Q&A, announcements, and community ideas — with categories, polls, and the ability to mark accepted answers. It is commonly used by open-source projects to engage maintainers and users.

--- a/package/github/github/components/issues.yml
+++ b/package/github/github/components/issues.yml
@@ -1,0 +1,6 @@
+id: 33267c31-3b30-4cc5-9497-7f9a2c5d6d01
+name: GitHub Issues
+description: >-
+  Plan, track, and discuss work with issues that integrate directly with your code, pull requests, and projects.
+background: >-
+  GitHub Issues lets teams track bugs, enhancements, tasks, and other work items. Issues support labels, milestones, assignees, task lists, templates, and cross-references to commits and pull requests, and they feed into GitHub Projects for planning.

--- a/package/github/github/components/packages.yml
+++ b/package/github/github/components/packages.yml
@@ -1,0 +1,6 @@
+id: 777f185e-9083-4fd8-8d42-10206deb6677
+name: GitHub Packages
+description: >-
+  Host and manage software packages — including container images and npm, Maven, Gradle, NuGet, and RubyGems artifacts — alongside your source code.
+background: >-
+  GitHub Packages is a software package hosting service that lets you publish packages privately or publicly and consume them as dependencies in your projects. It integrates with GitHub's permissions and billing, ties package access to repository and organization permissions, and supports multiple registries including the Container registry (ghcr.io), npm, Maven, Gradle, NuGet, and RubyGems.

--- a/package/github/github/components/pages.yml
+++ b/package/github/github/components/pages.yml
@@ -1,0 +1,6 @@
+id: 338284de-2b23-48b7-8762-948a76788b57
+name: GitHub Pages
+description: >-
+  A static site hosting service that publishes websites directly from a GitHub repository.
+background: >-
+  GitHub Pages takes HTML, CSS, and JavaScript files — optionally built with Jekyll or a GitHub Actions workflow — straight from a repository and publishes them as a website. It supports custom domains and HTTPS, and is commonly used for project documentation, personal and organization sites, and blogs.

--- a/package/github/github/components/projects.yml
+++ b/package/github/github/components/projects.yml
@@ -1,0 +1,6 @@
+id: 5203bbff-0f48-4ebf-a76f-cca5379f5504
+name: GitHub Projects
+description: >-
+  An adaptable, spreadsheet-and-board planning tool that organizes issues and pull requests into customizable views.
+background: >-
+  GitHub Projects is a flexible project-planning tool built on top of issues and pull requests. It offers table, board, and roadmap views, custom fields, grouping, filtering, and automation, letting teams plan and track work without leaving GitHub.

--- a/package/github/github/components/sponsors.yml
+++ b/package/github/github/components/sponsors.yml
@@ -1,0 +1,6 @@
+id: 55957467-689f-4406-8de6-a0d981941e22
+name: GitHub Sponsors
+description: >-
+  A funding platform that lets the community financially support the developers and organizations who build open-source software.
+background: >-
+  GitHub Sponsors enables developers and organizations to receive recurring or one-time financial contributions from the community for their open-source work. Maintainers set up sponsorship tiers, and GitHub processes the payments.

--- a/package/github/github/editions/pro.yml
+++ b/package/github/github/editions/pro.yml
@@ -3,40 +3,31 @@ name: Pro
 description: >-
   Github Pro is an extension of the free for personal accounts edition.
 background: >-
-  In addition to the features available with GitHub Free for organizations, GitHub Team includes:
+  In addition to the features available with GitHub Free for personal accounts, GitHub Pro includes:
 
   - GitHub Support via email
   - 3,000 GitHub Actions minutes per month
   - 2 GB GitHub Packages storage
-  - The option to purchase GitHub Advanced Security products:
-    - GitHub Code Security
-    - GitHub Secret Protection
-
-    For more information, see About GitHub Advanced Security.
+  - 180 GitHub Codespaces core hours per month
+  - 20 GB GitHub Codespaces storage per month
   - Advanced tools and insights in private repositories:
     - Required pull request reviewers
     - Multiple pull request reviewers
-    - Team pull request reviewers
     - Protected branches
     - Code owners
-    - Scheduled reminders
+    - Auto-linked references
     - GitHub Pages
+
     ```
       Note:
       To publish a GitHub Pages site privately, you need to have an organization account.
       Additionally, your organization must use GitHub Enterprise Cloud.
     ````
+
     - Wikis
-    - Security overview
     - Repository insights graphs: Pulse, contributors, traffic, commits, code frequency, network, and forks
+
     ```
       Note:
       Certain contributor, commit, and code frequency insights are only available for repositories that have less than 10,000 commits.
     ````
-
-  - The option to enable or disable GitHub Codespaces
-    - Organization owners can choose to enable or disable GitHub Codespaces for the organization's private repositories, and can pay for the usage of members and collaborators. For more information, see Enabling or disabling GitHub Codespaces for your organization and Choosing who owns and pays for codespaces in your organization.
-
-  GitHub bills for GitHub Team on a per-user basis. For more information, see About per-user pricing.
-
-  GitHub Actions usage is free for standard GitHub-hosted runners in public repositories, and for self-hosted runners. See Choosing the runner for a job. For private repositories, each GitHub account receives a certain amount of free minutes and storage for use with GitHub-hosted runners, depending on the account's plan. Any usage beyond the included amounts is controlled by spending limits.

--- a/package/github/github/editions/team.yml
+++ b/package/github/github/editions/team.yml
@@ -3,31 +3,40 @@ name: Team
 description: >-
   Github Team is an extension of the free for organizations edition.
 background: >-
-  In addition to the features available with GitHub Free for personal accounts, GitHub Pro includes:
+  In addition to the features available with GitHub Free for organizations, GitHub Team includes:
 
   - GitHub Support via email
   - 3,000 GitHub Actions minutes per month
   - 2 GB GitHub Packages storage
-  - 180 GitHub Codespaces core hours per month
-  - 20 GB GitHub Codespaces storage per month
+  - The option to purchase GitHub Advanced Security products:
+    - GitHub Code Security
+    - GitHub Secret Protection
+
+    For more information, see About GitHub Advanced Security.
   - Advanced tools and insights in private repositories:
     - Required pull request reviewers
     - Multiple pull request reviewers
+    - Team pull request reviewers
     - Protected branches
     - Code owners
-    - Auto-linked references
+    - Scheduled reminders
     - GitHub Pages
-
     ```
       Note:
       To publish a GitHub Pages site privately, you need to have an organization account.
       Additionally, your organization must use GitHub Enterprise Cloud.
     ````
-
     - Wikis
+    - Security overview
     - Repository insights graphs: Pulse, contributors, traffic, commits, code frequency, network, and forks
-
     ```
       Note:
       Certain contributor, commit, and code frequency insights are only available for repositories that have less than 10,000 commits.
     ````
+
+  - The option to enable or disable GitHub Codespaces
+    - Organization owners can choose to enable or disable GitHub Codespaces for the organization's private repositories, and can pay for the usage of members and collaborators. For more information, see Enabling or disabling GitHub Codespaces for your organization and Choosing who owns and pays for codespaces in your organization.
+
+  GitHub bills for GitHub Team on a per-user basis. For more information, see About per-user pricing.
+
+  GitHub Actions usage is free for standard GitHub-hosted runners in public repositories, and for self-hosted runners. See Choosing the runner for a job. For private repositories, each GitHub account receives a certain amount of free minutes and storage for use with GitHub-hosted runners, depending on the account's plan. Any usage beyond the included amounts is controlled by spending limits.

--- a/package/github/github/index.yml
+++ b/package/github/github/index.yml
@@ -6,38 +6,44 @@ created: '2024-02-27T21:16:37.780Z'
 updated: '2025-03-17T13:12:17.150Z'
 code: github
 status: active
-description: GitHub ...Build and ship software on a single, collaborative platform
-  ..
+description: >-
+  GitHub is an AI-powered developer platform to build, scale, and deliver secure
+  software, with Git-based version control, pull-request code review, issues,
+  CI/CD via Actions, package hosting, and team collaboration.
 aliases:
-- github.github
-- github.github
-- github.github
-- github.github
-- github.github
 - github.github
 logo: https://cdn.auditmation.io/logos/github-github.svg
 url: https://github.com/
+apiDocsUrl: https://docs.github.com/en/rest
 vendorId: 075189d1-f253-5eab-b698-89514f327da0
 vendorCode: github
 parentType: vendor
 tags: []
+segments:
+- 9f902198-8bf1-48a1-93f8-e00de5a0e459 # Version Control Hosting Platform - the core GitHub platform
+- 479884a4-c12f-4c00-80fe-d177d3f2ac4d # Distributed VCS - Git
+- 24a63195-e677-42bd-8e4f-8e3916ca5e7c # Version Control Systems - repos / branches / pull requests
+- 61cbad35-4a81-4848-8a15-a476f7b16d0e # Software Development - overall developer platform
+- b5704a21-cbef-4df5-83ba-89e838d5c91a # CI/CD - GitHub Actions
+- 216815ee-499f-42b4-accd-f886bf17e145 # Package Hosting Service - GitHub Packages
+- 428bfdc1-ea92-45dc-8ea3-21f0f3d6a2cc # AI Coding Assistant - GitHub Copilot
+- 74e42317-354a-4a30-a180-01dea2f6381e # Dependency Management - Dependabot
+- 60529bd4-0cb1-40dd-ae5c-8b0073e80fba # Software Composition Analysis - code scanning / Advanced Security
 cpeProducts:
-- github:gaug.es
 - github:github
 - github:enterprise_server
+- github:cli
+- github:codeql_cli
 - github:codeql_action
-- github:owslib
-- github:gh-ost
-- github:viewcomponent
-- github:cmark-gfm
-- github:toolkit
-- github:pull_requests_and_issues
 - github:runner
-- github:btcsuite_go-socks
-- github:491-project
+- github:gh-ost
 - github:hub
+- github:cmark-gfm
+- github:viewcomponent
+- github:toolkit
 factoryTypes:
   - software
-hostingTypes: []
+hostingTypes:
+  - saas
 environment: dev
 hostname: https://api.ci.zerobias.com


### PR DESCRIPTION
## What

Accuracy improvements to the **GitHub** product catalog entry — the first real run of our product-research/review process. Targets `dev` for validation before prod (per the test-in-dev-first plan); merge loads it into the dev env.

## Changes

### `index.yml`
- **`segments` — added 9** (none existed before). UUID ↔ segment ↔ satisfying feature:

  | segment | satisfied by |
  |---|---|
  | Version Control Hosting Platform (`t_vchp`) | core GitHub platform |
  | Distributed VCS (`t_dvcs`) | Git |
  | Version Control Systems (`c_vcs`) | repos / branches / pull requests |
  | Software Development (`d_sd`) | overall developer platform |
  | CI/CD (`t_cicd`) | GitHub Actions |
  | Package Hosting Service (`s_phs`) | GitHub Packages |
  | AI Coding Assistant (`t_aica`) | GitHub Copilot |
  | Project Dependency Management (`t_pdm`) | Dependabot |
  | Software Composition Analysis (`t_sca`) | code scanning / Advanced Security |

  (The YAML carries trailing `#` comments mapping each UUID to its name for readers; the first four are the essential/primary ones — trim the rest if you prefer a tighter set.)
- **`apiDocsUrl`** — added (`https://docs.github.com/en/rest`), was missing.
- **`hostingTypes`** — `[]` → `[saas]` (was empty).
- **`aliases`** — deduped (6 identical `github.github` → 1; likely a generation bug).
- **`description`** — rewritten (was a fragment with stray ellipses).
- **`cpeProducts`** — cleaned (drives automatic CVE attribution; verified against the **NVD CPE API 2.0** on 2026-06-05):

  | removed | NVD records | reason |
  |---|---|---|
  | `github:gaug.es` | 2 | defunct (Gauges analytics, shut down 2018) |
  | `github:owslib` | 1 | third-party Python geospatial lib, not a GitHub product |
  | `github:btcsuite_go-socks` | ~0 | third-party Bitcoin Go lib merely hosted on GitHub |
  | `github:491-project` | ~0 | obscure third-party repo |
  | `github:pull_requests_and_issues` | ~0 | feature concept, already covered by `github:github` |

  | added | NVD records | what |
  |---|---|---|
  | `github:cli` | 196 | GitHub CLI (`gh`) |
  | `github:codeql_cli` | 131 | CodeQL CLI |

  Kept GitHub first-party software: `github`, `enterprise_server`, `codeql_action`, `runner`, `gh-ost`, `hub`, `cmark-gfm`, `viewcomponent`, `toolkit`.

### `editions/`
- **Fixed a real data bug:** `pro.yml` and `team.yml` had their `background` blocks **swapped** (pro.yml's text said "GitHub Team includes…", team.yml's said "GitHub Pro includes…"). Un-swapped to their correct files.

### `components/`
- **Added 11 missing sub-products** (only `dependabot` existed): `actions`, `packages`, `codespaces`, `copilot`, `advanced-security`, `pages`, `issues`, `projects`, `discussions`, `sponsors`, `advisory-database`. Same shape as the existing component (`id`/`name`/`description`/`background`).

## Flagged for reviewer decision (intentionally NOT changed)
- `status: active` — repo convention for new entries is `verified`; left as-is.
- `environment: dev` / `hostname:` in `index.yml` look like **dataloader-injected fields that leaked into source** — left as-is; candidate for a separate cleanup.
- `editions/enterprise.yml` collapses **Enterprise Cloud** + **Enterprise Server** (distinct deployment models) into one edition — deferred (would split into two).
- `editions/free_organization.yml` — verify it's still a current GitHub plan.
- `catalog.yml` (679 operations) is an **older API snapshot** (missing codespaces/packages/copilot/dependabot namespaces) — **out of scope** here (it's generated from the API spec, not hand-edited).
- Provenance (`sourceUrl`/`verifiedAt`) was **intentionally not added to the YAML** — the current edition/component schema only accepts `id/name/description/background`.

## Validation
- All 14 changed/new YAML files parse cleanly.
- CPE tokens verified against NVD CPE API 2.0.
- Full gate / dataloader validation runs in dev CI on merge.

## Sources
GitHub docs (plans, products, REST API, auth) · NVD CPE API 2.0 (`cpe:2.3:*:github:*`).
