### PR TITLE
fix(build): make plugin-repo credentials blank-aware (unblocks publish)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,8 +12,13 @@ pluginManagement {
         maven {
             url = uri("https://maven.pkg.github.com/zerobias-org/util")
             credentials {
-                username = System.getenv("GITHUB_ACTOR") ?: "zerobias-org"
-                password = System.getenv("READ_TOKEN") ?: System.getenv("NPM_TOKEN") ?: System.getenv("GITHUB_TOKEN") ?: ""
+                username = System.getenv("GITHUB_ACTOR")?.takeIf(String::isNotBlank) ?: "zerobias-org"
+                // `?:` only falls through on null, not on an empty string. CI can export
+                // READ_TOKEN set-but-empty, which would short-circuit the fallback and
+                // auth with a blank password (401 → "plugin not found"). Skip blanks so a
+                // later valid token (e.g. NPM_TOKEN) is used.
+                password = listOf("READ_TOKEN", "NPM_TOKEN", "GITHUB_TOKEN")
+                    .firstNotNullOfOrNull { System.getenv(it)?.takeIf(String::isNotBlank) } ?: ""
             }
         }
         gradlePluginPortal()


### PR DESCRIPTION
## Problem
The publish `version` job fails resolving the `zb.workspace` Gradle plugin from GitHub Packages — `could not resolve plugin artifact 'zb.workspace:zb.workspace.gradle.plugin:1.+'` — even though the plugin (`1.0.116`) exists and the Vault tokens are valid.

## Root cause
`settings.gradle.kts` builds the GitHub Packages credential as:
```kotlin
password = System.getenv("READ_TOKEN") ?: System.getenv("NPM_TOKEN") ?: ...
```
Kotlin `?:` falls through only on **null**, not on an **empty string**. CI exports `READ_TOKEN` **set-but-empty**, so the chain stops at `""` and authenticates with a blank password (401), **never trying the valid `NPM_TOKEN`**.

## Fix
Pick the first **non-blank** token, so an empty `READ_TOKEN` falls through to `NPM_TOKEN`. Same hardening on the `GITHUB_ACTOR` username.

## Verified locally (clean Gradle home + clean `.m2`)
| Scenario | Result |
|---|---|
| `READ_TOKEN` = valid Vault `readPackagesToken` | ✅ SUCCESS |
| `NPM_TOKEN` = valid Vault `writePackagesToken`, READ unset | ✅ SUCCESS |
| `READ_TOKEN=""` + valid `NPM_TOKEN`, **before** fix | ❌ FAIL (reproduces CI) |
| `READ_TOKEN=""` + valid `NPM_TOKEN`, **after** fix | ✅ SUCCESS |

## Scope / note
Both Vault tokens are valid — this is **not** an expired secret. The proper root-cause fix (why `READ_TOKEN` is empty for `publishing-role` in the `version` job) is **devops-side**; this PR makes plugin resolution resilient to it so publishing is unblocked now. The identical fix is also up in `zerobias-org/product`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)