### PR TITLE
feat(product-stellarcyber-stellarcyber): add Stellar Cyber product

### DIFF
--- a/package/stellarcyber/stellarcyber/.npmrc
+++ b/package/stellarcyber/stellarcyber/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/stellarcyber/stellarcyber/build.gradle.kts
+++ b/package/stellarcyber/stellarcyber/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/stellarcyber/stellarcyber/catalog.yml
+++ b/package/stellarcyber/stellarcyber/catalog.yml
@@ -1,0 +1,76 @@
+Product:
+  name: Stellar Cyber
+  versions: [6.5.0]
+  package: stellarcyber.stellarcyber
+  description: |-
+    Stellar Cyber Open XDR. Cases are correlated groups of alerts (threat findings);
+    each case alert carries the resource context (GuardDuty finding, MITRE tactic/technique,
+    username, AWS account/region).
+  link: https://docs.stellarcyber.ai/6.5.xs/Using/API/API-Intro.htm
+  contentType: json
+Operations:
+  ListCases:
+    description: |-
+      List Stellar Cyber cases (correlated threat findings).
+    versions:
+      from: 6.5.0
+    link: https://docs.stellarcyber.ai/6.5.xs/Using/API/API-Case-Query.htm
+    example:
+      inputs: [
+        { "limit": 100, "status": "" }
+      ]
+      outputs: [
+        {
+          "data": {
+            "cases": [
+              {
+                "_id": "string",
+                "name": "string",
+                "severity": "Low|Medium|High|Critical",
+                "score": 0.0,
+                "size": 1,
+                "status": "string",
+                "created_at": 0,
+                "tenant_name": "string"
+              }
+            ]
+          }
+        }
+      ]
+  ListCaseAlerts:
+    description: |-
+      List the alerts within a case (the resource/threat detail). `skip` and `limit`
+      are both required (Stellar Cyber returns 422 if either is omitted).
+    versions:
+      from: 6.5.0
+    link: https://docs.stellarcyber.ai/6.5.xs/Using/API/API-Case-Query.htm
+    example:
+      inputs: [
+        { "caseId": "string", "skip": 0, "limit": 100 }
+      ]
+      outputs: [
+        {
+          "docs": [
+            {
+              "_id": "string",
+              "_source": {
+                "@timestamp": "string",
+                "severity": 0,
+                "username": "string",
+                "xdr_event": {
+                  "display_name": "string",
+                  "description": "string",
+                  "tactic": { "id": "string", "name": "string" },
+                  "technique": { "id": "string", "name": "string" }
+                },
+                "aws_guardduty": {
+                  "AccountId": "string",
+                  "Arn": "string",
+                  "Type": "string",
+                  "Resource": { "ResourceType": "string" }
+                }
+              }
+            }
+          ]
+        }
+      ]

--- a/package/stellarcyber/stellarcyber/index.yml
+++ b/package/stellarcyber/stellarcyber/index.yml
@@ -1,0 +1,19 @@
+id: 867a791a-e904-497d-92c1-92d4d6773bf7
+name: Stellar Cyber
+type: product
+ownerId: 00000000-0000-0000-0000-000000000000
+created: '2026-06-12T07:57:14.629Z'
+updated: '2026-06-12T07:57:14.629Z'
+code: stellarcyber
+status: active
+description: Stellar Cyber Open XDR — cases and alerts (correlated threat detections) with MITRE ATT&CK context and affected-resource ARNs.
+logo: https://cdn.auditmation.io/logos/stellarcyber-stellarcyber.svg
+url: https://docs.stellarcyber.ai/
+vendorId: 59a92c34-5f83-4414-83c7-41700b6fd594
+vendorCode: stellarcyber
+parentType: vendor
+apiDocsUrl: https://docs.stellarcyber.ai/6.5.xs/Using/API/API-Intro.htm
+tags: []
+factoryTypes:
+  - software
+hostingTypes: []

--- a/package/stellarcyber/stellarcyber/package.json
+++ b/package/stellarcyber/stellarcyber/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/product-stellarcyber-stellarcyber",
+  "version": "1.0.0-rc.1",
+  "description": "Product package for product stellarcyber",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/product.git",
+    "directory": "product/"
+  },
+  "dependencies": {
+    "@zerobias-org/vendor-stellarcyber": "latest"
+  },
+  "files": [
+    "catalog.yml",
+    "components/**",
+    "editions/**",
+    "index.yml",
+    "logo.*",
+    "supports.yml"
+  ],
+  "scripts": {
+    "correct:deps": "tsx ../../../scripts/correctDeps.ts"
+  },
+  "zerobias": {
+    "package": "stellarcyber.stellarcyber",
+    "import-artifact": "product",
+    "dataloader-version": "5.0.25"
+  }
+}


### PR DESCRIPTION
## Summary
New product: **Stellar Cyber** (`stellarcyber.stellarcyber`, vendor-parented). Open XDR cases & alerts (correlated threat detections) with MITRE ATT&CK context and affected-resource ARNs. Catalog covers `ListCases` / `ListCaseAlerts`.

**Depends on** zerobias-org/vendor#76 (`@zerobias-org/vendor-stellarcyber`) - merge that first.

## Files
- `package/stellarcyber/stellarcyber/index.yml` / `package.json` / `catalog.yml` / `.npmrc` / `build.gradle.kts`

## Validation
- [x] `./gradlew :stellarcyber:stellarcyber:validateContent` passes locally (670 unique ids; triangulation OK)
- [ ] `:gate` / `gate-stamp.json` - produced by CI
- [ ] Logo asset - follow-up

Schema classes (e.g. StellarCyberFinding) are intentionally **not** here - those belong in the module repo, matching how crowdstrike/qualys products carry no `components/`.

Generated with Claude Code.