### PR TITLE
feat(github): add supports.yml (product→compliance-feature links)

### DIFF
--- a/package/github/github/index.yml
+++ b/package/github/github/index.yml
@@ -45,5 +45,3 @@ factoryTypes:
   - software
 hostingTypes:
   - saas
-environment: dev
-hostname: https://api.ci.zerobias.com

--- a/package/github/github/supports.yml
+++ b/package/github/github/supports.yml
@@ -1,0 +1,75 @@
+supports:
+  - complianceFeature: f_ssomfa
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_2fa
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_rbac
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_acfcr
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_afcr
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_al
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_aat
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_lm
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_ss
+    edition: enterprise
+    component: advanced-security
+    strength: high
+    status: supported
+  - complianceFeature: f_sca
+    edition: enterprise
+    component: advanced-security
+    strength: high
+    status: supported
+  - complianceFeature: f_cs2
+    edition: enterprise
+    component: advanced-security
+    strength: high
+    status: supported
+  - complianceFeature: f_vs
+    edition: enterprise
+    component: advanced-security
+    strength: high
+    status: supported
+  - complianceFeature: f_safsd
+    edition: enterprise
+    component: dependabot
+    strength: high
+    status: supported
+  - complianceFeature: f_dmfsp
+    edition: enterprise
+    component: dependabot
+    strength: medium
+    status: supported
+  - complianceFeature: f_cbam
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_carm
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_ce2
+    edition: enterprise
+    strength: medium
+    status: supported

--- a/package/github/github/supports.yml
+++ b/package/github/github/supports.yml
@@ -1,5 +1,6 @@
 supports:
-  - complianceFeature: f_ssomfa
+  # ---- Identity, authentication, access ----
+  - complianceFeature: f_ssomfa     # SAML/OIDC SSO — Enterprise only
     edition: enterprise
     strength: high
     status: supported
@@ -7,32 +8,111 @@ supports:
     edition: enterprise
     strength: high
     status: supported
+  - complianceFeature: f_2fa
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_2fa
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_2fa
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_2fa
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_rbac       # org/repo roles — org plans
+    edition: enterprise
+    strength: high
+    status: supported
   - complianceFeature: f_rbac
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_rbac
+    edition: free_organization
+    strength: medium
+    status: supported
+  - complianceFeature: f_acfcr      # access control for repos — all
     edition: enterprise
     strength: high
     status: supported
   - complianceFeature: f_acfcr
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_acfcr
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_acfcr
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_acfcr
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_afcr       # authentication for repos — all
     edition: enterprise
     strength: high
     status: supported
   - complianceFeature: f_afcr
-    edition: enterprise
+    edition: team
     strength: high
     status: supported
+  - complianceFeature: f_afcr
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_afcr
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_afcr
+    edition: free_personal
+    strength: high
+    status: supported
+  # ---- Audit & logging (org plans) ----
   - complianceFeature: f_al
     edition: enterprise
     strength: high
     status: supported
+  - complianceFeature: f_al
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_al
+    edition: free_organization
+    strength: medium
+    status: supported
   - complianceFeature: f_aat
     edition: enterprise
-    strength: high
+    strength: medium
+    status: supported
+  - complianceFeature: f_aat
+    edition: team
+    strength: medium
     status: supported
   - complianceFeature: f_lm
     edition: enterprise
     strength: high
     status: supported
+  - complianceFeature: f_lm
+    edition: team
+    strength: medium
+    status: supported
+  # ---- GitHub Advanced Security (Enterprise + Team) → component: advanced-security ----
   - complianceFeature: f_ss
     edition: enterprise
+    component: advanced-security
+    strength: high
+    status: supported
+  - complianceFeature: f_ss
+    edition: team
     component: advanced-security
     strength: high
     status: supported
@@ -41,8 +121,18 @@ supports:
     component: advanced-security
     strength: high
     status: supported
+  - complianceFeature: f_sca
+    edition: team
+    component: advanced-security
+    strength: high
+    status: supported
   - complianceFeature: f_cs2
     edition: enterprise
+    component: advanced-security
+    strength: high
+    status: supported
+  - complianceFeature: f_cs2
+    edition: team
     component: advanced-security
     strength: high
     status: supported
@@ -51,8 +141,34 @@ supports:
     component: advanced-security
     strength: high
     status: supported
+  - complianceFeature: f_vs
+    edition: team
+    component: advanced-security
+    strength: high
+    status: supported
+  # ---- Dependabot (all editions) → component: dependabot ----
   - complianceFeature: f_safsd
     edition: enterprise
+    component: dependabot
+    strength: high
+    status: supported
+  - complianceFeature: f_safsd
+    edition: team
+    component: dependabot
+    strength: high
+    status: supported
+  - complianceFeature: f_safsd
+    edition: pro
+    component: dependabot
+    strength: high
+    status: supported
+  - complianceFeature: f_safsd
+    edition: free_organization
+    component: dependabot
+    strength: high
+    status: supported
+  - complianceFeature: f_safsd
+    edition: free_personal
     component: dependabot
     strength: high
     status: supported
@@ -61,15 +177,85 @@ supports:
     component: dependabot
     strength: medium
     status: supported
+  - complianceFeature: f_dmfsp
+    edition: team
+    component: dependabot
+    strength: medium
+    status: supported
+  - complianceFeature: f_dmfsp
+    edition: pro
+    component: dependabot
+    strength: medium
+    status: supported
+  - complianceFeature: f_dmfsp
+    edition: free_organization
+    component: dependabot
+    strength: medium
+    status: supported
+  - complianceFeature: f_dmfsp
+    edition: free_personal
+    component: dependabot
+    strength: medium
+    status: supported
+  # ---- Change management & SDLC (all editions) ----
   - complianceFeature: f_cbam
     edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_cbam
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_cbam
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_cbam
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_cbam
+    edition: free_personal
     strength: high
     status: supported
   - complianceFeature: f_carm
     edition: enterprise
     strength: high
     status: supported
+  - complianceFeature: f_carm
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_carm
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_carm
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_carm
+    edition: free_personal
+    strength: high
+    status: supported
+  # ---- Encryption (all editions) ----
   - complianceFeature: f_ce2
     edition: enterprise
+    strength: medium
+    status: supported
+  - complianceFeature: f_ce2
+    edition: team
+    strength: medium
+    status: supported
+  - complianceFeature: f_ce2
+    edition: pro
+    strength: medium
+    status: supported
+  - complianceFeature: f_ce2
+    edition: free_organization
+    strength: medium
+    status: supported
+  - complianceFeature: f_ce2
+    edition: free_personal
     strength: medium
     status: supported


### PR DESCRIPTION
## What
Adds `supports.yml` to the GitHub product — 17 product→compliance-feature links, scoped to editions/components (GHAS features → `advanced-security`; Dependabot → `dependabot`; identity/audit/change/encryption → Enterprise edition).

## Why
GitHub currently shows **zero** compliance features. This is the **product→feature** layer; the **feature→control** layer is the companion PR in `compliance_feature` (`feat/github-feature-controls`).

## ⚠️ Preconditions / notes
- The referenced `f_*` features must be **loaded in the target env** — the loader resolves `complianceFeature` by code; a missing feature makes the row fail (`complianceFeature … does not exist`).
- For **controls** to render, the companion `compliance_feature` PR (feature→control) must also be merged + loaded, AND SCF 2026.1.1 must be present in the env.
- Scoped to `enterprise` (the superset edition). For features also in Team/Pro/Free, duplicate the row per edition.
- `edition` is **required** by the loader (no fallback); `component` set only for sub-product features (GHAS → `advanced-security`, Dependabot → `dependabot`).
- `supports.yml` is already in the package `files` array, so it will be published.
