### PR TITLE
feat(github): extend supports.yml (+35 features), wire codeql to SAST

### DIFF
--- a/package/github/codeql/gate-stamp.json
+++ b/package/github/codeql/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.2",
-  "branch": "chore/migrate-vendor-parented-mopup",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "version": "2.0.2-uat.0",
+  "branch": "feat/github-catalog-links",
+  "sourceHash": "bb12d0df232659bb65bff7b44290d1afc35f9faa400bd826b430a3db9faa64af",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/github/codeql/index.yml
+++ b/package/github/codeql/index.yml
@@ -14,6 +14,8 @@ vendorId: 075189d1-f253-5eab-b698-89514f327da0
 vendorCode: github
 parentType: vendor
 tags: []
+segments:
+- 9818e413-3fb4-47bc-8854-2496a0baf72a # Static Application Security Testing (SAST)
 cpeProducts: []
 factoryTypes:
   - software

--- a/package/github/github/gate-stamp.json
+++ b/package/github/github/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.3-uat.0",
-  "branch": "HEAD",
-  "sourceHash": "d30395cb4a9c4bc1d92081bc81116ab9e71c8203c0301231daaca560e2da6fef",
+  "branch": "feat/github-catalog-links",
+  "sourceHash": "70d04ae7c3b5b58c50ff042097ed1aaedd72fceae82b707c6076c262dffa5b4e",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/github/github/supports.yml
+++ b/package/github/github/supports.yml
@@ -259,3 +259,824 @@ supports:
     edition: free_personal
     strength: medium
     status: supported
+  # ---- Developer platform capabilities (segments pass 2026-07) ----
+  - complianceFeature: f_chfcr
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_chfcr
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_chfcr
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_chfcr
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_chfcr
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_vhad
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_vhad
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_vhad
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_vhad
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_vhad
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_cvm2
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_cvm2
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_cvm2
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_cvm2
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_cvm2
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_naafcr
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_naafcr
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_naafcr
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_naafcr
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_naafcr
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_rm
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_rm
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_rm
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_rm
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_rm
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_sp
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_sp
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_sp
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_sp
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_sp
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_vcs
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_vcs
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_vcs
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_vcs
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_vcs
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_dfcr
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_dfcr
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_dfcr
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_dfcr
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_dfcr
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_crfcr
+    edition: free_personal
+    strength: medium
+    status: supported
+  - complianceFeature: f_crfcr
+    edition: free_organization
+    strength: medium
+    status: supported
+  - complianceFeature: f_crfcr
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_crfcr
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_crfcr
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_it
+    edition: free_personal
+    strength: high
+    status: supported
+    component: issues
+  - complianceFeature: f_it
+    edition: free_organization
+    strength: high
+    status: supported
+    component: issues
+  - complianceFeature: f_it
+    edition: pro
+    strength: high
+    status: supported
+    component: issues
+  - complianceFeature: f_it
+    edition: team
+    strength: high
+    status: supported
+    component: issues
+  - complianceFeature: f_it
+    edition: enterprise
+    strength: high
+    status: supported
+    component: issues
+  - complianceFeature: f_ab
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_ab
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_ab
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_ab
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_ab
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_da
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_da
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_da
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_da
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_da
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pac
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pac
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pac
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pac
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pac
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pdam
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pdam
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pdam
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pdam
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_pdam
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_naafp
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_naafp
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_naafp
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_naafp
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_naafp
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_shoc
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_shoc
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_shoc
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_shoc
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_shoc
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cicd
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cicd
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cicd
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cicd
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cicd
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_tt
+    edition: free_personal
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_tt
+    edition: free_organization
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_tt
+    edition: pro
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_tt
+    edition: team
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_tt
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_em
+    edition: free_personal
+    strength: low
+    status: partially_supported
+    component: actions
+  - complianceFeature: f_em
+    edition: free_organization
+    strength: low
+    status: partially_supported
+    component: actions
+  - complianceFeature: f_em
+    edition: pro
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_em
+    edition: team
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_em
+    edition: enterprise
+    strength: high
+    status: supported
+    component: actions
+  - complianceFeature: f_rc
+    edition: free_personal
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_rc
+    edition: free_organization
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_rc
+    edition: pro
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_rc
+    edition: team
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_rc
+    edition: enterprise
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cm
+    edition: free_personal
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cm
+    edition: free_organization
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cm
+    edition: pro
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cm
+    edition: team
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cm
+    edition: enterprise
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_ss
+    edition: free_personal
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_ss
+    edition: free_organization
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_ss
+    edition: pro
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_ss
+    edition: team
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_ss
+    edition: enterprise
+    strength: medium
+    status: supported
+    component: actions
+  - complianceFeature: f_iw_cp2
+    edition: free_personal
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_cp2
+    edition: free_organization
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_cp2
+    edition: pro
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_cp2
+    edition: team
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_cp2
+    edition: enterprise
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_phs
+    edition: free_personal
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_phs
+    edition: free_organization
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_phs
+    edition: pro
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_phs
+    edition: team
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_phs
+    edition: enterprise
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_chfsp
+    edition: free_personal
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_chfsp
+    edition: free_organization
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_chfsp
+    edition: pro
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_chfsp
+    edition: team
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_chfsp
+    edition: enterprise
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_am
+    edition: free_personal
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_am
+    edition: free_organization
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_am
+    edition: pro
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_am
+    edition: team
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_am
+    edition: enterprise
+    strength: high
+    status: supported
+    component: packages
+  - complianceFeature: f_iw_pdm
+    edition: free_personal
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_iw_pdm
+    edition: free_organization
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_iw_pdm
+    edition: pro
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_iw_pdm
+    edition: team
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_iw_pdm
+    edition: enterprise
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_aufsd
+    edition: free_personal
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_aufsd
+    edition: free_organization
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_aufsd
+    edition: pro
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_aufsd
+    edition: team
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_aufsd
+    edition: enterprise
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_sbomg
+    edition: free_personal
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_sbomg
+    edition: free_organization
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_sbomg
+    edition: pro
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_sbomg
+    edition: team
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_sbomg
+    edition: enterprise
+    strength: high
+    status: supported
+    component: dependabot
+  - complianceFeature: f_iw_it
+    edition: free_personal
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_it
+    edition: free_organization
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_it
+    edition: pro
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_it
+    edition: team
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_it
+    edition: enterprise
+    strength: high
+    status: supported
+  - complianceFeature: f_iw_cp
+    edition: free_personal
+    strength: medium
+    status: supported
+  - complianceFeature: f_iw_cp
+    edition: free_organization
+    strength: medium
+    status: supported
+  - complianceFeature: f_iw_cp
+    edition: pro
+    strength: medium
+    status: supported
+  - complianceFeature: f_iw_cp
+    edition: team
+    strength: medium
+    status: supported
+  - complianceFeature: f_iw_cp
+    edition: enterprise
+    strength: medium
+    status: supported
+  - complianceFeature: f_iw_des
+    edition: free_personal
+    strength: high
+    status: supported
+    component: codespaces
+  - complianceFeature: f_iw_des
+    edition: free_organization
+    strength: high
+    status: supported
+    component: codespaces
+  - complianceFeature: f_iw_des
+    edition: pro
+    strength: high
+    status: supported
+    component: codespaces
+  - complianceFeature: f_iw_des
+    edition: team
+    strength: high
+    status: supported
+    component: codespaces
+  - complianceFeature: f_iw_des
+    edition: enterprise
+    strength: high
+    status: supported
+    component: codespaces
+  - complianceFeature: f_aipf
+    edition: free_personal
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aipf
+    edition: free_organization
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aipf
+    edition: pro
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aipf
+    edition: team
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aipf
+    edition: enterprise
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aicg
+    edition: free_personal
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aicg
+    edition: free_organization
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aicg
+    edition: pro
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aicg
+    edition: team
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_aicg
+    edition: enterprise
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_atg
+    edition: free_personal
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_atg
+    edition: free_organization
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_atg
+    edition: pro
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_atg
+    edition: team
+    strength: medium
+    status: supported
+    component: copilot
+  - complianceFeature: f_atg
+    edition: enterprise
+    strength: medium
+    status: supported
+    component: copilot


### PR DESCRIPTION
Extends the GitHub product's edition-aware compliance-feature support and connects CodeQL to the compliance graph. (Rebased onto `main` — all GitHub content goes directly to main.)

## Changes
- **`github/github/supports.yml`**: +175 entries across **35 features** (VCS core, Actions/CI-CD, Packages, Dependabot, Codespaces, Copilot). The 17 features already curated (f_2fa, f_ssomfa, f_rbac, …) are **untouched** — on overlap, the existing rows win at feature level.
- **`github/codeql/index.yml`**: adds `segments: [t_sast]` (Static Application Security Testing) — CodeQL previously had no segments and contributed nothing to the compliance graph.
- Both packages pass `./gradlew :github:github:gate :github:codeql:gate` (fresh gate-stamps).

## ⚠️ SME review
- **Edition matrix is research-based** (docs.github.com plans + 2025 GHAS unbundling changelogs): e.g. `f_em` (environments) partially_supported on free tiers (public repos only).
- Strength values use medium/low where support is real but weaker — segment supports precedent uses only `high`.
- 3 feature codes referenced here (`f_aicg`, `f_sbomg`, `f_crfcr`) are new — they publish when zerobias-org/compliance_feature#14 merges; **merge that PR first** so dataload resolves them.
- Component attributions (e.g. f_iw_cp2 → packages/ghcr, f_atg → copilot) are judgment calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
